### PR TITLE
[tower-async]: patch: ensure features like make::MakeService can be used with async Service

### DIFF
--- a/tower-async/src/lib.rs
+++ b/tower-async/src/lib.rs
@@ -8,6 +8,7 @@
 #![allow(incomplete_features)]
 #![feature(async_fn_in_trait)]
 #![feature(impl_trait_projections)]
+#![feature(return_type_notation)]
 #![allow(elided_lifetimes_in_paths, clippy::type_complexity)]
 #![cfg_attr(test, allow(clippy::float_cmp))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg))]

--- a/tower-async/src/make/make_service.rs
+++ b/tower-async/src/make/make_service.rs
@@ -221,3 +221,55 @@ where
         self.make.make_service(target).await
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+
+    use super::*;
+
+
+    #[derive(Debug, Clone)]
+    struct EchoService;
+
+    impl<R> Service<R> for EchoService {
+        type Response = R;
+        type Error = Infallible;
+
+        async fn call(&mut self, req: R) -> Result<Self::Response, Self::Error> {
+            Ok(req)
+        }
+    }
+
+    async fn higher_order_async_fn<F, R>(mut factory: F, req: R) -> R
+    where
+        F: MakeService<(), R, Response = R>,
+        F::MakeError: std::fmt::Debug,
+        F::Error: std::fmt::Debug,
+        F::Response: std::fmt::Debug,
+        F::Service: Service<R, call(): Send> + Send + 'static,
+        R: Send + 'static,
+    {
+        let mut svc = factory.make_service(()).await.unwrap();
+
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        tokio::spawn(async move {
+            let resp = svc.call(req).await.unwrap();
+            tx.send(resp).unwrap();
+        })
+        .await
+        .unwrap();
+
+        rx.await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn higher_order_async_fn_with_make_fn() {
+        let shared = |_: ()| async { Ok::<_, Infallible>(EchoService) };
+
+        let res = higher_order_async_fn(shared, "foo").await;
+
+        assert_eq!(res, "foo");
+    }
+}

--- a/tower-async/src/make/make_service/shared.rs
+++ b/tower-async/src/make/make_service/shared.rs
@@ -89,7 +89,9 @@ mod tests {
         tokio::spawn(async move {
             let resp = svc.call(req).await.unwrap();
             tx.send(resp).unwrap();
-        }).await.unwrap();
+        })
+        .await
+        .unwrap();
 
         rx.await.unwrap()
     }

--- a/tower-async/src/make/make_service/shared.rs
+++ b/tower-async/src/make/make_service/shared.rs
@@ -60,4 +60,46 @@ mod tests {
 
         assert_eq!(res, "foo");
     }
+
+    #[derive(Debug, Clone)]
+    struct EchoService;
+
+    impl<R> Service<R> for EchoService {
+        type Response = R;
+        type Error = Infallible;
+
+        async fn call(&mut self, req: R) -> Result<Self::Response, Self::Error> {
+            Ok(req)
+        }
+    }
+
+    async fn higher_order_async_fn<F, R>(mut factory: F, req: R) -> R
+    where
+        F: MakeService<(), R, Response = R>,
+        F::MakeError: std::fmt::Debug,
+        F::Error: std::fmt::Debug,
+        F::Response: std::fmt::Debug,
+        F::Service: Service<R, call(): Send> + Send + 'static,
+        R: Send + 'static,
+    {
+        let mut svc = factory.make_service(()).await.unwrap();
+
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        tokio::spawn(async move {
+            let resp = svc.call(req).await.unwrap();
+            tx.send(resp).unwrap();
+        }).await.unwrap();
+
+        rx.await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn higher_order_async_fn_with_shared() {
+        let shared = Shared::new(EchoService);
+
+        let res = higher_order_async_fn(shared, "foo").await;
+
+        assert_eq!(res, "foo");
+    }
 }

--- a/tower-async/src/make/make_service/shared.rs
+++ b/tower-async/src/make/make_service/shared.rs
@@ -97,8 +97,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn higher_order_async_fn_with_shared() {
+    async fn higher_order_async_fn_with_shared_service_struct() {
         let shared = Shared::new(EchoService);
+
+        let res = higher_order_async_fn(shared, "foo").await;
+
+        assert_eq!(res, "foo");
+    }
+
+    #[tokio::test]
+    async fn higher_order_async_fn_with_shared_service_fn() {
+        let shared = Shared::new(service_fn(echo::<&'static str>));
 
         let res = higher_order_async_fn(shared, "foo").await;
 


### PR DESCRIPTION
Closes #9.